### PR TITLE
Exports special cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devonfw/ts-merger",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "2-way TypeScript Merger",
   "author": {
     "name": "Capgemini",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "typescript": "^2.2.1",
     "webpack": "^3.4.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ts-node": "^8.0.2"
+  },
   "directories": {
     "test": "test"
   },

--- a/test/export_test.ts
+++ b/test/export_test.ts
@@ -279,6 +279,40 @@ describe('Merging exports', () => {
     });
   });
 
+  describe('Should not mix imports and exports', () => {
+    const base = `import { O } from 'OS';
+    import { N } from 'NS';
+    export 'OC';
+    export const APIS = [ O, N ];`,
+      patch = `import { G } from 'GS';
+      export a, b from 'bla'
+      export const APIS = [G];`;
+
+    it('by default.', () => {
+      const result: String[] = merge(base, patch, false)
+        .split('\n')
+        .filter((r) => {
+          return r.trim() != '';
+        });
+      let exportRegex = /export\s*{\s*\w,\s*\w\s*}\s*from\s*'bla';/;
+      expect(
+        result.filter((value) => exportRegex.test(value.toString())).length,
+      ).equal(1);
+    });
+
+    it('when patchOverride is set (should not make a difference).', () => {
+      const result: String[] = merge(base, patch, true)
+        .split('\n')
+        .filter((r) => {
+          return r.trim() != '';
+        });
+      let exportRegex = /export\s*{\s*\w,\s*\w\s*}\s*from\s*'bla';/;
+      expect(
+        result.filter((value) => exportRegex.test(value.toString())).length,
+      ).equal(1);
+    });
+  });
+
   describe('in case of conflicts of the export name', () => {
     const base = `export { a as b } from 'c';`,
       patch = `export { a as d } from 'c';`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,10 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -618,6 +622,10 @@ des.js@^1.0.0:
 diff@3.2.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1423,6 +1431,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-error@^1.1.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -2099,7 +2111,7 @@ source-map-support@0.4.3:
   dependencies:
     source-map "^0.5.3"
 
-source-map-support@^0.5.0:
+source-map-support@^0.5.0, source-map-support@^0.5.6:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
   dependencies:
@@ -2300,6 +2312,16 @@ ts-loader@^2.1.0:
     enhanced-resolve "^3.0.0"
     loader-utils "^1.0.2"
     semver "^5.0.1"
+
+ts-node@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.0.2.tgz#9ecdf8d782a0ca4c80d1d641cbb236af4ac1b756"
+  dependencies:
+    arg "^4.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
 
 tslib@^1.7.1:
   version "1.7.1"
@@ -2576,3 +2598,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.0.0.tgz#0073c6b56e92aed652fbdfd62431f2d6b9a7a091"


### PR DESCRIPTION
There were some special cases on the `export` case that needed to be addressed:

`export a from 'b'`

is not the same as:

`export {a} from 'b'`