### PR TITLE
T54 fixed missing VariableStatement properties and missing CallStatements commas.

### DIFF
--- a/src/components/general/CallExpression.ts
+++ b/src/components/general/CallExpression.ts
@@ -59,6 +59,12 @@ export class CallExpression extends GeneralInterface {
     result.push(this.getIdentifier(), '.', this.getName(), '(');
     this.arguments.forEach((argument) => {
       result.push(argument.toString());
+      if (
+        this.getArguments().indexOf(argument) <
+        this.getArguments().length - 1
+      ) {
+        result.push(',');
+      }
     });
     result.push(')');
     return result.join('');

--- a/src/components/general/VariableStatement.ts
+++ b/src/components/general/VariableStatement.ts
@@ -6,11 +6,21 @@ import * as mergeTools from '../../tools/MergerTools';
 export class VariableStatement extends PropertyDeclaration {
   private const: boolean;
   private async: boolean;
+  private properties: String[];
 
   constructor() {
     super();
     this.const = false;
     this.async = false;
+    this.properties = [];
+  }
+
+  setProperties(properties: String[]) {
+    this.properties = properties;
+  }
+
+  getProperties() {
+    return this.properties;
   }
 
   setIsAsync(isAsync: boolean) {
@@ -75,6 +85,14 @@ export class VariableStatement extends PropertyDeclaration {
     result.push(this.getIdentifier());
     if (this.getType() != '') {
       result.push(': ', this.getType());
+    }
+
+    if (this.properties.length > 0) {
+      result.push(' {\n');
+      this.properties.forEach(property => {
+        result.push(' ', property, ',\n');
+      });
+      result.push('}');
     }
 
     if (this.getInitializer()) {

--- a/src/components/general/VariableStatement.ts
+++ b/src/components/general/VariableStatement.ts
@@ -63,6 +63,11 @@ export class VariableStatement extends PropertyDeclaration {
     } else if (patchOverrides) {
       this.setInitializer(patchVariable.getInitializer());
     }
+    mergeTools.mergeVariableProperties(
+      this.getProperties(),
+      patchVariable.getProperties(),
+      patchOverrides)
+
     mergeTools.mergeDecorators(
       this.getDecorators(),
       patchVariable.getDecorators(),

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -21,6 +21,7 @@ import { BodyMethod } from '../components/classDeclaration/members/method/body/B
 import InterfaceProperty from '../components/interfaceDeclaration/members/InterfaceProperty';
 import { EnumDeclaration } from '../components/general/EnumDeclaration';
 import { EnumElement } from '../components/general/EnumElement';
+import { SyntaxKind } from 'typescript';
 
 export function mapFile(sourceFile: ts.SourceFile) {
   let file: TSFile = new TSFile();
@@ -729,6 +730,17 @@ export function mapVariableStatement(
     variable.setIsConst(true);
   }
 
+  let properties = [];
+  let bindingElements = statement.declarationList.declarations[0].name['elements'];
+  if (bindingElements) {
+    bindingElements.forEach(bindingElement => {
+      if (bindingElement.kind == SyntaxKind.BindingElement) {
+        properties.push(bindingElement.name['escapedText'])
+      }
+    });
+    variable.setProperties(properties);
+  }
+
   let text = fileVariable.getFullText(source);
   let index = text.indexOf('await');
   if (index !== -1) {
@@ -762,8 +774,8 @@ export function mapVariableStatement(
       .initializer
   ) {
     switch (
-      (<ts.VariableStatement>statement).declarationList.declarations[0]
-        .initializer.kind
+    (<ts.VariableStatement>statement).declarationList.declarations[0]
+      .initializer.kind
     ) {
       case ts.SyntaxKind.ObjectLiteralExpression:
         variable.setInitializer(
@@ -788,10 +800,10 @@ export function mapVariableStatement(
       case ts.SyntaxKind.StringLiteral:
         variable.setInitializer(
           "'" +
-            (<ts.StringLiteral>(
-              fileVariable.declarationList.declarations[0].initializer
-            )).text +
-            "'",
+          (<ts.StringLiteral>(
+            fileVariable.declarationList.declarations[0].initializer
+          )).text +
+          "'",
         );
         break;
       case ts.SyntaxKind.TrueKeyword:

--- a/src/tools/MergerTools.ts
+++ b/src/tools/MergerTools.ts
@@ -158,6 +158,21 @@ export function mergeDecorators(
     }
   });
 }
+export function mergeVariableProperties(
+  baseVariableProperties: String[],
+  patchVariableProperties: String[],
+  patchOverrides: boolean
+) {
+  if (patchOverrides) {
+    return patchVariableProperties;
+  }
+
+  patchVariableProperties.forEach(property => {
+    if (baseVariableProperties.indexOf(property) == -1) {
+      baseVariableProperties.push(property);
+    }
+  });
+}
 
 export function mergeProperties(
   baseProperties: PropertyDeclaration[],


### PR DESCRIPTION
Addresses: #54 

Implemented changes: 
* Added extraction, merging, and generation of VariableStatement properties.
* Fixed missing comma when merging CallStatements. 

