### PR TITLE
Adding support of PropertyAssignments without keys and parameter with initial values

### DIFF
--- a/src/components/TSFile.ts
+++ b/src/components/TSFile.ts
@@ -4,8 +4,9 @@ import { ClassDeclaration } from './classDeclaration/ClassDeclaration';
 import { InterfaceDeclaration } from './interfaceDeclaration/InterfaceDeclaration';
 import { ImportDeclaration } from './import/ImportDeclaration';
 import { ExportDeclaration } from './export/ExportDeclaration';
-import * as mergeTools from '../tools/MergerTools';
 import { EnumDeclaration } from './general/EnumDeclaration';
+import { ExpressionDeclaration } from './general/ExpressionDeclaration';
+import * as mergeTools from '../tools/MergerTools';
 
 export class TSFile {
   private importDeclarations: ImportDeclaration[];
@@ -15,6 +16,7 @@ export class TSFile {
   private variables: VariableStatement[];
   private functions: FunctionDeclaration[];
   private enums: EnumDeclaration[];
+  private expressions: ExpressionDeclaration[];
 
   constructor() {
     this.importDeclarations = [];
@@ -24,6 +26,7 @@ export class TSFile {
     this.variables = [];
     this.functions = [];
     this.enums = [];
+    this.expressions = [];
   }
 
   addImport(importDeclaration: ImportDeclaration) {
@@ -56,6 +59,14 @@ export class TSFile {
 
   getEnums() {
     return this.enums;
+  }
+
+  addExpression(expressionToAdd: ExpressionDeclaration) {
+    this.expressions.push(expressionToAdd);
+  }
+
+  getExpressions() {
+    return this.expressions;
   }
 
   // setClass(classDeclaration: ClassDeclaration){
@@ -93,6 +104,7 @@ export class TSFile {
   merge(patchFile: TSFile, patchOverrides: boolean) {
     mergeTools.mergeImports(this, patchFile);
     mergeTools.mergeExports(this, patchFile);
+    mergeTools.mergeExpressions(this, patchFile, patchOverrides);
     this.checkAndMergeClasses(patchFile, patchOverrides);
     this.checkAndMergeInterfaces(patchFile, patchOverrides);
     this.checkAndMergeEnums(patchFile, patchOverrides);
@@ -182,6 +194,9 @@ export class TSFile {
 
     this.functions.forEach((func) => {
       file.push(func.toString());
+    });
+    this.expressions.forEach((expr) => {
+      file.push(expr.toString());
     });
     this.variables.forEach((variable) => {
       file.push(variable.toString());

--- a/src/components/classDeclaration/members/method/Parameter.ts
+++ b/src/components/classDeclaration/members/method/Parameter.ts
@@ -10,6 +10,7 @@ import { GeneralInterface } from '../../../general/GeneralInterface';
 export class Parameter extends GeneralInterface {
   private decorators: Decorator[];
   private modifiers: String[];
+  private initialValue: any;
 
   constructor() {
     super();
@@ -17,6 +18,13 @@ export class Parameter extends GeneralInterface {
     this.modifiers = [];
   }
 
+  getInitialValue() {
+    return this.initialValue;
+  }
+
+  setInitialValue(initialValue) {
+    this.initialValue = initialValue;
+  }
   addModifier(modifier: String) {
     this.modifiers.push(modifier);
   }
@@ -67,6 +75,7 @@ export class Parameter extends GeneralInterface {
       result.push(this.getIdentifier() + ': ' + this.getType());
     else result.push(this.getIdentifier());
 
+    if (this.getInitialValue()) result.push(' = ', this.getInitialValue().toString());
     return result.join('');
   }
 }

--- a/src/components/classDeclaration/members/method/Parameter.ts
+++ b/src/components/classDeclaration/members/method/Parameter.ts
@@ -10,7 +10,8 @@ import { GeneralInterface } from '../../../general/GeneralInterface';
 export class Parameter extends GeneralInterface {
   private decorators: Decorator[];
   private modifiers: String[];
-  private initialValue: any;
+  // initial value
+  private general: any;
 
   constructor() {
     super();
@@ -18,12 +19,12 @@ export class Parameter extends GeneralInterface {
     this.modifiers = [];
   }
 
-  getInitialValue() {
-    return this.initialValue;
+  getGeneral() {
+    return this.general;
   }
 
-  setInitialValue(initialValue) {
-    this.initialValue = initialValue;
+  setGeneral(general) {
+    this.general = general;
   }
   addModifier(modifier: String) {
     this.modifiers.push(modifier);
@@ -59,7 +60,7 @@ export class Parameter extends GeneralInterface {
     if (patchOverrides) {
       this.setType(patchParameter.getType());
       this.setModifiers(patchParameter.getModifiers());
-      this.setInitialValue(patchParameter.getInitialValue());
+      this.setGeneral(patchParameter.getGeneral());
     }
   }
 
@@ -76,7 +77,7 @@ export class Parameter extends GeneralInterface {
       result.push(this.getIdentifier() + ': ' + this.getType());
     else result.push(this.getIdentifier());
 
-    if (this.getInitialValue()) result.push(' = ', this.getInitialValue().toString());
+    if (this.getGeneral()) result.push(' = ', this.getGeneral().toString());
     return result.join('');
   }
 }

--- a/src/components/classDeclaration/members/method/Parameter.ts
+++ b/src/components/classDeclaration/members/method/Parameter.ts
@@ -59,6 +59,7 @@ export class Parameter extends GeneralInterface {
     if (patchOverrides) {
       this.setType(patchParameter.getType());
       this.setModifiers(patchParameter.getModifiers());
+      this.setInitialValue(patchParameter.getInitialValue());
     }
   }
 

--- a/src/components/classDeclaration/members/method/body/BodyMethod.ts
+++ b/src/components/classDeclaration/members/method/body/BodyMethod.ts
@@ -1,10 +1,13 @@
 import { VariableStatement } from '../../../../general/VariableStatement';
+import { ExpressionDeclaration } from '../../../../general/ExpressionDeclaration';
 
 export class BodyMethod {
   private statements: any[];
+  private isArrowFunction: boolean;
 
   constructor() {
     this.statements = [];
+    this.isArrowFunction = false;
   }
 
   addStatement(statement: any) {
@@ -17,6 +20,14 @@ export class BodyMethod {
 
   setStatements(statements: any[]) {
     this.statements = statements;
+  }
+
+  setIsArrowFunction(isArrowFunction: boolean) {
+    this.isArrowFunction = isArrowFunction;
+  }
+
+  getIsArrowFunction() {
+    return this.isArrowFunction;
   }
 
   merge(patchBody: BodyMethod, patchOverrides: boolean) {
@@ -35,6 +46,13 @@ export class BodyMethod {
               patchOverrides,
             );
           }
+        } else if (
+          patchStatement instanceof ExpressionDeclaration &&
+          statement instanceof ExpressionDeclaration
+        ) {
+          if (statement.getName() === patchStatement.getName()) {
+            statement.merge(patchStatement, patchOverrides);
+          }
         }
       });
     });
@@ -42,6 +60,10 @@ export class BodyMethod {
 
   toString() {
     let result: String[] = [];
+
+    if (this.isArrowFunction) {
+      result.push('() => ');
+    }
     result.push('{ \n');
     this.statements.forEach((statement) => {
       result.push(statement.toString());

--- a/src/components/classDeclaration/members/property/PropertyDeclaration.ts
+++ b/src/components/classDeclaration/members/property/PropertyDeclaration.ts
@@ -9,11 +9,13 @@ export class PropertyDeclaration extends GeneralInterface {
   private modifiers: String[];
   private decorators: Decorator[];
   private initializer: any;
+  private isOptional: boolean;
 
   constructor() {
     super();
     this.modifiers = [];
     this.decorators = [];
+    this.isOptional = false;
   }
 
   addDecorator(decorator: Decorator) {
@@ -60,10 +62,19 @@ export class PropertyDeclaration extends GeneralInterface {
     return this.initializer;
   }
 
+  setIsOptional(isOptional: boolean) {
+    this.isOptional = isOptional;
+  }
+
+  getIsOptional() {
+    return this.isOptional;
+  }
+
   merge(patchProperty: PropertyDeclaration, patchOverrides: boolean) {
     if (patchOverrides) {
       this.setType(patchProperty.getType());
       this.setModifiers(patchProperty.getModifiers());
+      this.isOptional = patchProperty.getIsOptional();
     }
 
     mergeTools.mergeDecorators(
@@ -111,6 +122,11 @@ export class PropertyDeclaration extends GeneralInterface {
       result.push(modifier, ' ');
     });
     result.push(this.getIdentifier());
+
+    if (this.isOptional) {
+      result.push('?');
+    }
+
     if (this.getType() != '') {
       result.push(': ', this.getType());
     }

--- a/src/components/general/ArrayLiteralExpression.ts
+++ b/src/components/general/ArrayLiteralExpression.ts
@@ -2,9 +2,14 @@ import { PropertyAssignment } from './PropertyAssignment';
 import { CallExpression } from './CallExpression';
 import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 import { GeneralInterface } from './GeneralInterface';
+import { SyntaxKind } from 'typescript';
+import { EnumDeclaration } from './EnumDeclaration';
+import { ExpressionDeclaration } from './ExpressionDeclaration';
+import { VariableStatement } from './VariableStatement';
 
 export class ArrayLiteralExpression {
   private elements: any[];
+  readonly kind: number = SyntaxKind.ArrayLiteralExpression;
 
   constructor() {
     this.elements = [];
@@ -30,15 +35,58 @@ export class ArrayLiteralExpression {
         if (patchElement.toString() === element.toString()) {
           exists = true;
         }
-        // else if(patchElement instanceof ObjectLiteralExpression && element instanceof ObjectLiteralExpression) {
-        //     (<ObjectLiteralExpression>element).merge(<ObjectLiteralExpression>patchElement, patchOverrides);
-        // }
+        else {
+          // check whether element has the kind property
+          if ((element.kind) && (patchElement.kind)) {
+            // check whether both elements have the same kind
+            let sameType = patchElement.kind == element.kind;
+            if (sameType) {
+              let kind = element.kind;
+              switch (kind) {
+                case SyntaxKind.CallExpression:
+                  if (patchElement.getName() == element.getName()) {
+                    (<CallExpression>element).merge(<CallExpression>patchElement, patchOverrides);
+                    exists = true;
+                  }
+                  break;
+                case SyntaxKind.EnumDeclaration:
+                  if (patchElement.getName() == element.getName()) {
+                    (<EnumDeclaration>element).merge(<EnumDeclaration>element, <EnumDeclaration>patchElement, patchOverrides);
+                    exists = true;
+                  }
+                  break;
+                case SyntaxKind.ExpressionStatement:
+                  if (patchElement.getName() == element.getName()) {
+                    (<ExpressionDeclaration>element).merge(<ExpressionDeclaration>patchElement, patchOverrides);
+                    exists = true;
+                  }
+                  break;
+
+                case SyntaxKind.PropertyAssignment:
+                  if (patchElement.getIdentifier() == element.getIdentifier()) {
+                    (<PropertyAssignment>element).merge(<PropertyAssignment>patchElement, patchOverrides);
+                    exists = true;
+                  }
+                  break;
+                case SyntaxKind.VariableStatement:
+                  if (patchElement.getIdentifier() == element.getIdentifier()) {
+                    (<VariableStatement>element).merge(<VariableStatement>patchElement, patchOverrides);
+                    exists = true;
+                  }
+                  break;
+                default:
+                  break;
+              }
+            }
+          }
+        }
       });
       if (!exists) {
         this.addElement(patchElement);
       }
     });
   }
+
 
   toString() {
     let result: String[] = [];

--- a/src/components/general/CallExpression.ts
+++ b/src/components/general/CallExpression.ts
@@ -1,9 +1,11 @@
 import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 import { GeneralInterface } from './GeneralInterface';
+import { SyntaxKind } from 'typescript';
 
 export class CallExpression extends GeneralInterface {
   private name: String;
   private arguments: any[];
+  readonly kind: number = SyntaxKind.CallExpression;
 
   constructor() {
     super();

--- a/src/components/general/EnumDeclaration.ts
+++ b/src/components/general/EnumDeclaration.ts
@@ -1,11 +1,12 @@
-import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 import { EnumElement } from './EnumElement';
 
 export class EnumDeclaration {
   private name: String;
   private elements: EnumElement[];
+  private modifiers: String[];
 
   constructor() {
+    this.modifiers = [];
     this.name = '';
     this.elements = [];
   }
@@ -30,11 +31,33 @@ export class EnumDeclaration {
     this.elements = args;
   }
 
+  addModifier(modifier: String) {
+    this.modifiers.push(modifier);
+  }
+
+  addModifiers(modifiers: String[]) {
+    modifiers.forEach((modifier) => {
+      this.modifiers.push(modifier);
+    });
+  }
+
+  getModifiers() {
+    return this.modifiers;
+  }
+
+  setModifiers(modifiers: String[]) {
+    this.modifiers = modifiers;
+  }
+
   merge(
     baseEnum: EnumDeclaration,
     patchEnum: EnumDeclaration,
     patchOverrides: boolean,
   ) {
+    if (patchOverrides) {
+      this.setModifiers(patchEnum.getModifiers());
+    }
+
     let exists: boolean;
     patchEnum.getElements().forEach((patchElement) => {
       exists = false;
@@ -54,6 +77,10 @@ export class EnumDeclaration {
 
   toString() {
     let result: String[] = [];
+
+    this.modifiers.forEach((modifier) => {
+      result.push(modifier, ' ');
+    });
 
     result.push('enum ', this.getName(), ' {');
     this.elements.forEach((element) => {

--- a/src/components/general/EnumDeclaration.ts
+++ b/src/components/general/EnumDeclaration.ts
@@ -1,9 +1,11 @@
 import { EnumElement } from './EnumElement';
+import { SyntaxKind } from 'typescript';
 
 export class EnumDeclaration {
   private name: String;
   private elements: EnumElement[];
   private modifiers: String[];
+  readonly kind: number = SyntaxKind.EnumDeclaration;
 
   constructor() {
     this.modifiers = [];

--- a/src/components/general/ExpressionDeclaration.ts
+++ b/src/components/general/ExpressionDeclaration.ts
@@ -1,0 +1,99 @@
+import { GeneralInterface } from '../general/GeneralInterface';
+import ExportDeclaration from '../export/ExportDeclaration';
+import { BodyMethod } from '../classDeclaration/members/method/body/BodyMethod';
+import { createPartiallyEmittedExpression } from 'typescript';
+import { ObjectLiteralExpression } from './ObjectLiteralExpression';
+
+/**
+ * Defines the structure of script functions
+ *
+ * @export
+ * @class ExpressionDeclaration
+ */
+export class ExpressionDeclaration extends GeneralInterface {
+  private arguments: any[];
+  private name: string;
+
+  constructor() {
+    super();
+    this.arguments = [];
+  }
+
+  setName(name: string) {
+    this.name = name;
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  addArgument(argument: any) {
+    this.arguments.push(argument);
+  }
+
+  addArguments(argumentsArray: any[]) {
+    argumentsArray.forEach((argument) => {
+      this.arguments.push(argument);
+    });
+  }
+
+  getArguments() {
+    return this.arguments;
+  }
+
+  setArguments(argumentsArray: any[]) {
+    this.arguments = argumentsArray;
+  }
+
+  merge(patchExpression: ExpressionDeclaration, patchOverrides: boolean) {
+    let argumentExists: boolean;
+
+    patchExpression.getArguments().forEach((patchArgument) => {
+      argumentExists = false;
+      this.getArguments().forEach((argument) => {
+        if (this.areBodyMethodInstances(argument, patchArgument)) {
+          argument.merge(patchArgument, patchOverrides);
+          argumentExists = true;
+        } else if (this.areObjectLiteralInstances(argument, patchArgument)) {
+          (<ObjectLiteralExpression>argument).merge(
+            <ObjectLiteralExpression>patchArgument,
+            patchOverrides,
+          );
+          argumentExists = true;
+        } else if (patchArgument === argument) {
+          argumentExists = true;
+        }
+      });
+      if (!argumentExists) {
+        this.addArgument(patchArgument);
+      }
+    });
+  }
+
+  private areObjectLiteralInstances(argument: any, patchArgument: any) {
+    return (
+      argument instanceof ObjectLiteralExpression &&
+      patchArgument instanceof ObjectLiteralExpression
+    );
+  }
+
+  private areBodyMethodInstances(argument: any, patchArgument: any) {
+    return (
+      argument instanceof BodyMethod && patchArgument instanceof BodyMethod
+    );
+  }
+
+  toString() {
+    let result: String[] = [];
+
+    result.push(this.name, '.(');
+    this.getArguments().forEach((arg) => {
+      result.push(arg.toString(), ', ');
+    });
+    result.push(');');
+
+    return result.join('');
+  }
+}
+
+export default ExportDeclaration;

--- a/src/components/general/ExpressionDeclaration.ts
+++ b/src/components/general/ExpressionDeclaration.ts
@@ -3,6 +3,7 @@ import ExportDeclaration from '../export/ExportDeclaration';
 import { BodyMethod } from '../classDeclaration/members/method/body/BodyMethod';
 import { createPartiallyEmittedExpression } from 'typescript';
 import { ObjectLiteralExpression } from './ObjectLiteralExpression';
+import { SyntaxKind } from 'typescript';
 
 /**
  * Defines the structure of script functions
@@ -13,6 +14,7 @@ import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 export class ExpressionDeclaration extends GeneralInterface {
   private arguments: any[];
   private name: string;
+  readonly kind = SyntaxKind.ExpressionStatement
 
   constructor() {
     super();

--- a/src/components/general/ObjectLiteralExpression.ts
+++ b/src/components/general/ObjectLiteralExpression.ts
@@ -1,8 +1,10 @@
 import { PropertyAssignment } from './PropertyAssignment';
 import { GeneralInterface } from './GeneralInterface';
+import { SyntaxKind } from 'typescript';
 
 export class ObjectLiteralExpression {
   private properties: PropertyAssignment[];
+  readonly kind: number = SyntaxKind.ObjectLiteralExpression;
 
   constructor() {
     this.properties = [];

--- a/src/components/general/PropertyAssignment.ts
+++ b/src/components/general/PropertyAssignment.ts
@@ -2,9 +2,11 @@ import { CallExpression } from './CallExpression';
 import { ArrayLiteralExpression } from './ArrayLiteralExpression';
 import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 import { GeneralInterface } from './GeneralInterface';
+import { SyntaxKind } from 'typescript';
 
 export class PropertyAssignment extends GeneralInterface {
   private general: any;
+  readonly kind: number = SyntaxKind.PropertyAssignment;
 
   constructor() {
     super();

--- a/src/components/general/PropertyAssignment.ts
+++ b/src/components/general/PropertyAssignment.ts
@@ -49,7 +49,11 @@ export class PropertyAssignment extends GeneralInterface {
   }
 
   toString() {
-    return this.getIdentifier() + ': ' + this.getGeneral().toString();
+    let general = "";
+    if (this.getGeneral()) {
+      general = ': ' + this.getGeneral().toString();
+    }
+    return this.getIdentifier() + general;
   }
 }
 

--- a/src/components/general/VariableStatement.ts
+++ b/src/components/general/VariableStatement.ts
@@ -2,11 +2,13 @@ import { ArrayLiteralExpression } from './ArrayLiteralExpression';
 import { ObjectLiteralExpression } from './ObjectLiteralExpression';
 import { PropertyDeclaration } from '../classDeclaration/members/property/PropertyDeclaration';
 import * as mergeTools from '../../tools/MergerTools';
+import { SyntaxKind } from 'typescript';
 
 export class VariableStatement extends PropertyDeclaration {
   private const: boolean;
   private async: boolean;
   private properties: String[];
+  readonly kind = SyntaxKind.VariableStatement;
 
   constructor() {
     super();

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -24,49 +24,6 @@ import { EnumElement } from '../components/general/EnumElement';
 import { SyntaxKind } from 'typescript';
 
 
-function setExtractedObjectValues(readObject, extractedObject, sourceFile: ts.SourceFile): void {
-  switch (readObject.initializer.kind) {
-    case ts.SyntaxKind.Identifier:
-      extractedObject.setGeneral((<ts.Identifier>readObject.initializer).text);
-      break;
-    case ts.SyntaxKind.ArrayLiteralExpression:
-      extractedObject.setGeneral(
-        mapArrayLiteral(
-          (<ts.ArrayLiteralExpression>readObject.initializer).elements,
-          sourceFile,
-        ),
-      );
-      break;
-    case ts.SyntaxKind.ObjectLiteralExpression:
-      extractedObject.setGeneral(
-        mapObjectLiteral(
-          <ts.ObjectLiteralExpression>readObject.initializer,
-          sourceFile,
-        ),
-      );
-      break;
-    case ts.SyntaxKind.StringLiteral:
-      extractedObject.setGeneral(
-        "'" + (<ts.StringLiteral>readObject.initializer).text + "'",
-      );
-      break;
-    case ts.SyntaxKind.NullKeyword:
-      extractedObject.setIGeneral('null');
-      break;
-    case ts.SyntaxKind.CallExpression:
-      extractedObject.setGeneral(
-        mapCallExpression(
-          <ts.CallExpression>readObject.initializer,
-          sourceFile,
-        ),
-      );
-      break;
-    default:
-      extractedObject.setGeneral(
-        readObject.initializer.getFullText(sourceFile),
-      );
-  }
-}
 
 export function mapFile(sourceFile: ts.SourceFile) {
   let file: TSFile = new TSFile();
@@ -144,6 +101,50 @@ export function mapObjectLiteral(
   });
 
   return objLiteral;
+}
+
+function setExtractedObjectValues(readObject, extractedObject, sourceFile: ts.SourceFile): void {
+  switch (readObject.initializer.kind) {
+    case ts.SyntaxKind.Identifier:
+      extractedObject.setGeneral((<ts.Identifier>readObject.initializer).text);
+      break;
+    case ts.SyntaxKind.ArrayLiteralExpression:
+      extractedObject.setGeneral(
+        mapArrayLiteral(
+          (<ts.ArrayLiteralExpression>readObject.initializer).elements,
+          sourceFile,
+        ),
+      );
+      break;
+    case ts.SyntaxKind.ObjectLiteralExpression:
+      extractedObject.setGeneral(
+        mapObjectLiteral(
+          <ts.ObjectLiteralExpression>readObject.initializer,
+          sourceFile,
+        ),
+      );
+      break;
+    case ts.SyntaxKind.StringLiteral:
+      extractedObject.setGeneral(
+        "'" + (<ts.StringLiteral>readObject.initializer).text + "'",
+      );
+      break;
+    case ts.SyntaxKind.NullKeyword:
+      extractedObject.setIGeneral('null');
+      break;
+    case ts.SyntaxKind.CallExpression:
+      extractedObject.setGeneral(
+        mapCallExpression(
+          <ts.CallExpression>readObject.initializer,
+          sourceFile,
+        ),
+      );
+      break;
+    default:
+      extractedObject.setGeneral(
+        readObject.initializer.getFullText(sourceFile),
+      );
+  }
 }
 
 export function mapCallExpression(

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -92,8 +92,7 @@ export function mapObjectLiteral(
     let propertyFromFile = <ts.PropertyAssignment>property;
     let propertyAssignment: PropertyAssignment = new PropertyAssignment();
     propertyAssignment.setIdentifier((<ts.Identifier>property.name).text);
-    let initializer = propertyFromFile.initializer;
-    if (initializer) {
+    if (propertyFromFile.initializer) {
       switch (propertyFromFile.initializer.kind) {
         case ts.SyntaxKind.ArrayLiteralExpression:
           propertyAssignment.setGeneral(

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -20,9 +20,7 @@ import { BodyMethod } from '../components/classDeclaration/members/method/body/B
 import InterfaceProperty from '../components/interfaceDeclaration/members/InterfaceProperty';
 import { EnumDeclaration } from '../components/general/EnumDeclaration';
 import { EnumElement } from '../components/general/EnumElement';
-import { SyntaxKind } from 'typescript';
-
-
+import { ExpressionDeclaration } from '../components/general/ExpressionDeclaration';
 
 export function mapFile(sourceFile: ts.SourceFile) {
   let file: TSFile = new TSFile();
@@ -58,6 +56,12 @@ export function mapFile(sourceFile: ts.SourceFile) {
           break;
         case ts.SyntaxKind.EnumDeclaration:
           file.addEnum(mapEnums(<ts.EnumDeclaration>child));
+          break;
+        case ts.SyntaxKind.ExpressionStatement:
+          file.addExpression(
+            mapExpressions(<ts.ExpressionStatement>child, sourceFile),
+          );
+          break;
       }
     });
   return file;
@@ -86,6 +90,37 @@ export function mapEnums(enumfromFile: ts.EnumDeclaration) {
   });
 
   return enumOb;
+}
+
+export function mapExpressions(
+  expressionfromFile: ts.ExpressionStatement,
+  sourceFile: ts.SourceFile,
+) {
+  let expressionOb: ExpressionDeclaration = new ExpressionDeclaration();
+
+  let innerExpression: any = expressionfromFile.expression;
+  if (innerExpression) {
+    if (innerExpression.text) {
+      expressionOb.setName(innerExpression.text);
+    } else {
+      let text = (<ts.Identifier>innerExpression.expression).text;
+      if (text) {
+        expressionOb.setName(text);
+      } else {
+        // When we have a expression like TestBed.configureTestingModule({...})
+        text =
+          innerExpression.expression.expression.text +
+          '.' +
+          innerExpression.expression.name.text;
+        expressionOb.setName(text);
+      }
+      expressionOb.addArguments(
+        mapArguments(innerExpression.arguments, sourceFile),
+      );
+    }
+  }
+
+  return expressionOb;
 }
 
 export function mapObjectLiteral(
@@ -174,23 +209,48 @@ export function mapCallExpression(
   }
   expression.setName((<ts.Identifier>propExpr.name).text);
   if (node.arguments) {
-    node.arguments.forEach((argument) => {
-      switch (argument.kind) {
-        case ts.SyntaxKind.ObjectLiteralExpression:
-          expression.addArgument(
-            mapObjectLiteral(<ts.ObjectLiteralExpression>argument, sourceFile),
-          );
-          break;
-        case ts.SyntaxKind.StringLiteral:
-          expression.addArgument("'" + (<ts.StringLiteral>argument).text + "'");
-          break;
-        case ts.SyntaxKind.Identifier:
-          expression.addArgument((<ts.Identifier>argument).text);
-          break;
-      }
+    mapArguments(node.arguments, sourceFile).forEach((arg) => {
+      expression.addArgument(arg);
     });
   }
   return expression;
+}
+
+export function mapArguments(
+  argumentsVar: ts.NodeArray<ts.Expression>,
+  sourceFile: ts.SourceFile,
+) {
+  let argumentsArray: any[] = [];
+
+  argumentsVar.forEach((argument) => {
+    switch (argument.kind) {
+      case ts.SyntaxKind.ObjectLiteralExpression:
+        argumentsArray.push(
+          mapObjectLiteral(<ts.ObjectLiteralExpression>argument, sourceFile),
+        );
+        break;
+      case ts.SyntaxKind.StringLiteral:
+        argumentsArray.push("'" + (<ts.StringLiteral>argument).text + "'");
+        break;
+      case ts.SyntaxKind.Identifier:
+        argumentsArray.push((<ts.Identifier>argument).text);
+        break;
+      case ts.SyntaxKind.ArrowFunction:
+        let functionBody: ts.ConciseBody = (<ts.ArrowFunction>argument).body;
+
+        if (functionBody) {
+          let bodyMethod = mapBodyMethod(
+            functionBody.getFullText(sourceFile),
+            true,
+          );
+          bodyMethod.setIsArrowFunction(true);
+          argumentsArray.push(bodyMethod);
+        }
+        break;
+    }
+  });
+
+  return argumentsArray;
 }
 
 export function mapArrayLiteral(
@@ -316,7 +376,9 @@ export function mapClass(
           );
           let ctr: Constructor = mapConstructor(fileCtr, sourceFile);
           if (fileCtr.body) {
-            ctr.setBody(mapBodyMethod(fileCtr.body.getFullText(sourceFile)));
+            ctr.setBody(
+              mapBodyMethod(fileCtr.body.getFullText(sourceFile), false),
+            );
           }
           classTo.setConstructor(ctr);
 
@@ -327,7 +389,7 @@ export function mapClass(
 
           if (fileMethod.body) {
             method.setBody(
-              mapBodyMethod(fileMethod.body.getFullText(sourceFile)),
+              mapBodyMethod(fileMethod.body.getFullText(sourceFile), false),
             );
           }
           classTo.addMethod(method);
@@ -718,7 +780,7 @@ export function mapDecorator(
   return decorators;
 }
 
-export function mapBodyMethod(body: String) {
+export function mapBodyMethod(body: String, isScriptFunction: boolean) {
   let bodySource: ts.SourceFile = ts.createSourceFile(
     'body',
     <string>body,
@@ -740,6 +802,15 @@ export function mapBodyMethod(body: String) {
                   bodySource,
                 ),
               );
+              break;
+            case ts.SyntaxKind.ExpressionStatement:
+              if (isScriptFunction) {
+                bodyMethod.addStatement(
+                  mapExpressions(<ts.ExpressionStatement>statement, bodySource),
+                );
+              } else {
+                bodyMethod.addStatement(statement.getFullText(bodySource));
+              }
               break;
             default:
               bodyMethod.addStatement(statement.getFullText(bodySource));
@@ -764,7 +835,7 @@ export function mapVariableStatement(
   let bindingElements = statement.declarationList.declarations[0].name['elements'];
   if (bindingElements) {
     bindingElements.forEach(bindingElement => {
-      if (bindingElement.kind == SyntaxKind.BindingElement) {
+      if (bindingElement.kind == ts.SyntaxKind.BindingElement) {
         properties.push(bindingElement.name['escapedText'])
       }
     });
@@ -889,7 +960,9 @@ export function mapFunction(
   }
 
   if (fileFunction.body) {
-    func.setBody(mapBodyMethod(fileFunction.body.getFullText(sourceFile)));
+    func.setBody(
+      mapBodyMethod(fileFunction.body.getFullText(sourceFile), false),
+    );
   }
 
   return func;

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -404,6 +404,11 @@ export function mapPropertyDeclaration(
       prop.addDecorators(mapDecorator(<ts.Decorator>decorator, sourceFile));
     });
   }
+
+  if (property.questionToken) {
+    prop.setIsOptional(true);
+  }
+
   if (property.initializer) {
     switch (property.initializer.kind) {
       case ts.SyntaxKind.ObjectLiteralExpression:

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -535,6 +535,49 @@ export function mapParameter(
   }
   param.setIdentifier((<ts.Identifier>parameter.name).text);
   if (parameter.type) param.setType(mapTypes(parameter.type));
+  if (parameter.initializer) {
+    switch (parameter.initializer.kind) {
+      case ts.SyntaxKind.Identifier:
+        param.setInitialValue((<ts.Identifier>parameter.initializer).text);
+        break;
+      case ts.SyntaxKind.ArrayLiteralExpression:
+        param.setInitialValue(
+          mapArrayLiteral(
+            (<ts.ArrayLiteralExpression>parameter.initializer).elements,
+            sourceFile,
+          ),
+        );
+        break;
+      case ts.SyntaxKind.ObjectLiteralExpression:
+        param.setInitialValue(
+          mapObjectLiteral(
+            <ts.ObjectLiteralExpression>parameter.initializer,
+            sourceFile,
+          ),
+        );
+        break;
+      case ts.SyntaxKind.StringLiteral:
+        param.setInitialValue(
+          "'" + (<ts.StringLiteral>parameter.initializer).text + "'",
+        );
+        break;
+      case ts.SyntaxKind.NullKeyword:
+        param.setInitialValue('null');
+        break;
+      case ts.SyntaxKind.CallExpression:
+        param.setInitialValue(
+          mapCallExpression(
+            <ts.CallExpression>parameter.initializer,
+            sourceFile,
+          ),
+        );
+        break;
+      default:
+        param.setInitialValue(
+          parameter.initializer.getFullText(sourceFile),
+        );
+    }
+  }
   return param;
 }
 

--- a/src/tools/MappingTools.ts
+++ b/src/tools/MappingTools.ts
@@ -92,48 +92,51 @@ export function mapObjectLiteral(
     let propertyFromFile = <ts.PropertyAssignment>property;
     let propertyAssignment: PropertyAssignment = new PropertyAssignment();
     propertyAssignment.setIdentifier((<ts.Identifier>property.name).text);
-    switch (propertyFromFile.initializer.kind) {
-      case ts.SyntaxKind.ArrayLiteralExpression:
-        propertyAssignment.setGeneral(
-          mapArrayLiteral(
-            (<ts.ArrayLiteralExpression>propertyFromFile.initializer).elements,
-            sourceFile,
-          ),
-        );
-        break;
-      case ts.SyntaxKind.ObjectLiteralExpression:
-        propertyAssignment.setGeneral(
-          mapObjectLiteral(
-            <ts.ObjectLiteralExpression>propertyFromFile.initializer,
-            sourceFile,
-          ),
-        );
-        break;
-      case ts.SyntaxKind.Identifier:
-        propertyAssignment.setGeneral(
-          (<ts.Identifier>propertyFromFile.initializer).text,
-        );
-        break;
-      case ts.SyntaxKind.StringLiteral:
-        propertyAssignment.setGeneral(
-          "'" + (<ts.StringLiteral>propertyFromFile.initializer).text + "'",
-        );
-        break;
-      case ts.SyntaxKind.NullKeyword:
-        propertyAssignment.setGeneral('null');
-        break;
-      case ts.SyntaxKind.CallExpression:
-        propertyAssignment.setGeneral(
-          mapCallExpression(
-            <ts.CallExpression>propertyFromFile.initializer,
-            sourceFile,
-          ),
-        );
-        break;
-      default:
-        propertyAssignment.setGeneral(
-          propertyFromFile.initializer.getFullText(sourceFile),
-        );
+    let initializer = propertyFromFile.initializer;
+    if (initializer) {
+      switch (propertyFromFile.initializer.kind) {
+        case ts.SyntaxKind.ArrayLiteralExpression:
+          propertyAssignment.setGeneral(
+            mapArrayLiteral(
+              (<ts.ArrayLiteralExpression>propertyFromFile.initializer).elements,
+              sourceFile,
+            ),
+          );
+          break;
+        case ts.SyntaxKind.ObjectLiteralExpression:
+          propertyAssignment.setGeneral(
+            mapObjectLiteral(
+              <ts.ObjectLiteralExpression>propertyFromFile.initializer,
+              sourceFile,
+            ),
+          );
+          break;
+        case ts.SyntaxKind.Identifier:
+          propertyAssignment.setGeneral(
+            (<ts.Identifier>propertyFromFile.initializer).text,
+          );
+          break;
+        case ts.SyntaxKind.StringLiteral:
+          propertyAssignment.setGeneral(
+            "'" + (<ts.StringLiteral>propertyFromFile.initializer).text + "'",
+          );
+          break;
+        case ts.SyntaxKind.NullKeyword:
+          propertyAssignment.setGeneral('null');
+          break;
+        case ts.SyntaxKind.CallExpression:
+          propertyAssignment.setGeneral(
+            mapCallExpression(
+              <ts.CallExpression>propertyFromFile.initializer,
+              sourceFile,
+            ),
+          );
+          break;
+        default:
+          propertyAssignment.setGeneral(
+            propertyFromFile.initializer.getFullText(sourceFile),
+          );
+      }
     }
     objLiteral.addProperty(propertyAssignment);
   });

--- a/src/tools/MergerTools.ts
+++ b/src/tools/MergerTools.ts
@@ -56,6 +56,35 @@ export function mergeExports(baseFile: TSFile, patchFile: TSFile) {
   }
 }
 
+export function mergeExpressions(
+  baseFile: TSFile,
+  patchFile: TSFile,
+  patchOverrides,
+) {
+  let exists: boolean;
+
+  if (baseFile.getExpressions().length === 0) {
+    patchFile.getExpressions().forEach((patchExpressionStatement) => {
+      baseFile.addExpression(patchExpressionStatement);
+    });
+  } else {
+    patchFile.getExpressions().forEach((patchExpressionStatement) => {
+      exists = false;
+      baseFile.getExpressions().forEach((expressionStatement) => {
+        if (
+          expressionStatement.getName() === patchExpressionStatement.getName()
+        ) {
+          expressionStatement.merge(patchExpressionStatement, patchOverrides);
+          exists = true;
+        }
+      });
+      if (!exists) {
+        baseFile.addExpression(patchExpressionStatement);
+      }
+    });
+  }
+}
+
 export function mergeClass(
   baseClass: ClassDeclaration,
   patchClass: ClassDeclaration,

--- a/test/arrow_functions_test.ts
+++ b/test/arrow_functions_test.ts
@@ -1,0 +1,47 @@
+import merge from '../src/index';
+import { expect } from 'chai';
+import 'mocha';
+
+describe('should merge expression statements', () => {
+  const base = `describe('SidenavSharedService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [],
+      imports: [
+        RouterTestingModule,
+        CoreModule,
+      ],
+    });
+  });`,
+    patch = `describe('arg', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [],
+      imports: [
+        patchImport,
+      ],
+    });
+  });`;
+  it('including arrow functions.', () => {
+    const result: String[] = merge(base, patch, false)
+      .split('\n')
+      .map((value) => value.trim())
+      .filter((value) => value != '');
+    expect(
+      result.filter((res) =>
+        /describe\.\('SidenavSharedService',\s*\(\)\s*=>\s*{/.test(
+          res.toString(),
+        ),
+      ),
+    ).length.to.be.greaterThan(
+      0,
+      'base should have its two parameters untouched',
+    );
+    expect(
+      result.filter((res) => /patchImport/.test(res.toString())),
+    ).length.to.be.greaterThan(0, 'should have merged patch import too');
+    expect(
+      result.filter((res) => /},\s*'arg',\s*\);/.test(res.toString())),
+    ).length.to.be.greaterThan(0, 'should have merged patch argument too');
+  });
+});

--- a/test/class_decorator_test.ts
+++ b/test/class_decorator_test.ts
@@ -191,3 +191,36 @@ describe('Merging class decorators', () => {
     });
   });
 });
+describe('Property without initialized value', () => {
+  const base = `  
+  @NgModule({
+    declarations: [AppComponent],
+    imports: [
+      StoreModule.forRoot(reducers, {
+        metaReducers,
+        runtimeChecks: {
+          strictStateImmutability: true,
+          strictActionImmutability: true,
+        },
+      }),
+    ],
+    providers: [],
+    bootstrap: [],
+  })
+  export class AppModule {}
+    `,
+    patch = ``;
+
+  it('should be preserved from base.', () => {
+    const result: String[] = merge(base, patch, false)
+      .split('\n')
+      .map((value) => value.trim())
+      .filter((value) => value != '');
+
+    expect(result.length).equal(20);
+    expect(result[6]).to.be.equal(
+      'metaReducers,',
+      'metaReducers should not have an initial value as in base'
+    )
+  });
+});

--- a/test/class_decorator_test.ts
+++ b/test/class_decorator_test.ts
@@ -191,6 +191,7 @@ describe('Merging class decorators', () => {
     });
   });
 });
+
 describe('Property without initialized value', () => {
   const base = `  
   @NgModule({
@@ -209,18 +210,45 @@ describe('Property without initialized value', () => {
   })
   export class AppModule {}
     `,
-    patch = ``;
+    patch = `
+    @NgModule({
+      declarations: [AppComponent],
+      imports: [
+        StoreModule.forRoot(reducers, {
+          blaBla,
+          runtimeChecks: {
+            strictStateImmutability: true,
+            strictActionImmutability: true,
+          },
+        }),
+      ],
+      providers: [],
+      bootstrap: [],
+    })
+    export class AppModule {}
+    `;
+  const patchDecoratorRegex = /.*blaBla,.*/;
+  const baseDecoratorRegex = /.*metaReducers,.*/;
 
   it('should be preserved from base.', () => {
-    const result: String[] = merge(base, patch, false)
+    const result: String = merge(base, patch, false)
       .split('\n')
       .map((value) => value.trim())
-      .filter((value) => value != '');
+      .filter((value) => value != '')
+      .reduce((prev, curr) => prev.toString() + curr.toString(), "");;
 
-    expect(result.length).equal(20);
-    expect(result[6]).to.be.equal(
-      'metaReducers,',
-      'metaReducers should not have an initial value as in base'
-    )
+
+    expect(baseDecoratorRegex.test(result.toString()), 'metaReducers of the base should be present').to.be.true;
+    expect(patchDecoratorRegex.test(result.toString()), 'blaBla of the patch should not be present').to.be.false;
+  });
+
+  it('should be overwritten by patch.', () => {
+    const result: String = merge(base, patch, true)
+      .split('\n')
+      .map((value) => value.trim())
+      .filter((value) => value != '')
+      .reduce((prev, curr) => prev.toString() + curr.toString(), "");;
+    expect(baseDecoratorRegex.test(result.toString()), 'metaReducers of the base not should be present').to.be.false;
+    expect(patchDecoratorRegex.test(result.toString()), 'blaBla of the patch should be present').to.be.true;
   });
 });

--- a/test/class_field_test.ts
+++ b/test/class_field_test.ts
@@ -79,4 +79,30 @@ describe('Merging class fields', () => {
       );
     });
   });
+
+  describe('should add the optional token', () => {
+    const base = `class a { b?: string; }`,
+      patch = `class a { b: string; }`;
+
+    it('from the base.', () => {
+      const result: String[] = merge(base, patch, false)
+        .split('\n') // get each individual line
+        .map((value) => value.trim()) // trim all lines (no white spaces at the beginning and end of a line)
+        .filter((value) => value != ''); // remove empty lines
+      expect(result.indexOf('b?: string;')).to.be.greaterThan(
+        0,
+        'optional token should be present in class a',
+      );
+    });
+    it('from the patch with patchOverride.', () => {
+      const result: String[] = merge(base, patch, true)
+        .split('\n')
+        .map((value) => value.trim())
+        .filter((value) => value != '');
+      expect(result.indexOf('b: string;')).to.be.greaterThan(
+        0,
+        'optional token should not be present in class a',
+      );
+    });
+  });
 });

--- a/test/class_method_test.ts
+++ b/test/class_method_test.ts
@@ -206,4 +206,35 @@ describe('Merging class methods', () => {
       );
     });
   });
+
+  describe('should merge destructuring arrays', () => {
+    const base = `class a {
+      openConfirm(): void {
+        const payload: any = {
+          id: this.selectedRow.id,
+          searchTerms: { ...this.bla },
+        };
+      }
+    }`,
+      patch = `class a {
+        openConfirm(): void {
+          const payload: any = {
+            searchTerms: { ...this.searchTerms },
+          };
+        }`;
+    it('having two destructuring array values.', () => {
+      const result: String[] = merge(base, patch, false)
+        .split('\n')
+        .map((value) => value.trim())
+        .filter((value) => value != '');
+      expect(
+        result.filter((res) => /bla\s*:\s*...this.bla,/.test(res.toString())),
+      ).length.to.be.greaterThan(0, 'f should have modifier from base');
+      expect(
+        result.filter((res) =>
+          /searchTerms\s*:\s*...this.searchTerms/.test(res.toString()),
+        ),
+      ).length.to.be.greaterThan(0, 'f should have modifier from base');
+    });
+  });
 });

--- a/test/class_method_test.ts
+++ b/test/class_method_test.ts
@@ -12,10 +12,10 @@ describe('Merging class methods', () => {
      * OpenAPI spec version: 1.0
      */
     class a {
-                      private b(b:any):void{
-                          // Do Something
-                      }
-                  }`,
+              private b(b:any):void{
+                  // Do Something
+              }
+            }`,
       patch = `class a {
                   private c(b:any):number{
                       return 1;
@@ -59,10 +59,10 @@ describe('Merging class methods', () => {
      * OpenAPI spec version: 1.0
      */
     class a {
-                      private b(a:any):void{
-                          let c = 5;
-                      }
-                  }`,
+              private b(a:any):void{
+                let c = 5;
+                }
+              }`,
       patch = `
       /**
        * Should format correctly this line
@@ -71,9 +71,9 @@ describe('Merging class methods', () => {
        * OpenAPI spec version: 2.0
        */
       class a {
-                  private b(a:any):void{
-                      let d = 6;
-                  }
+                private b(a:any):void{
+                    let d = 6;
+                }
               }`;
 
     it('the base if method is present in base and patch.', () => {

--- a/test/enum_test.ts
+++ b/test/enum_test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import 'mocha';
 
 describe('should merge enums', () => {
-  const base = `enum Direction {
+  const base = `export enum Direction {
                   Up = 1,
                   Down = 2,
               }`,
@@ -20,7 +20,7 @@ describe('should merge enums', () => {
       .filter((value) => value != '');
     expect(
       result.filter((res) =>
-        /enum\s+Direction\s*\{\s*Up\s*=\s*1,\s*Down\s*=\s*2,\s*Left\s*=\s*3,\s*Right\s*=\s*4,\s*}/.test(
+        /export\s*enum\s+Direction\s*\{\s*Up\s*=\s*1,\s*Down\s*=\s*2,\s*Left\s*=\s*3,\s*Right\s*=\s*4,\s*}/.test(
           res.toString(),
         ),
       ),

--- a/test/export_test.ts
+++ b/test/export_test.ts
@@ -262,29 +262,6 @@ describe('Merging exports', () => {
     });
   });
 
-  describe('Should remove invalid exports', () => {
-    const base = `export 'b';`,
-      patch = `export 'c';`;
-
-    it('by default.', () => {
-      const result: String[] = merge(base, patch, false)
-        .split('\n')
-        .filter((r) => {
-          return r.trim() != '';
-        });
-      expect(result.length).equal(0);
-    });
-
-    it('when patchOverride is set (should not make a difference).', () => {
-      const result: String[] = merge(base, patch, true)
-        .split('\n')
-        .filter((r) => {
-          return r.trim() != '';
-        });
-      expect(result.length).equal(0);
-    });
-  });
-
   describe('Should not mix imports and exports', () => {
     const base = `import { O } from 'OS';
     import { N } from 'NS';

--- a/test/parameter_initial_values_test.ts
+++ b/test/parameter_initial_values_test.ts
@@ -1,0 +1,47 @@
+import merge from '../src/index';
+import { expect } from 'chai';
+import 'mocha';
+
+describe('should use the modifier from', () => {
+  const base = `
+ export function reducer(
+   state: SampleDataState = initialState,
+   action: SampleDataAction,
+ ): SampleDataState {
+      return state;
+ }
+  `,
+    patch = `  
+   export function reducer(
+     state: SampleDataState,
+     action: SampleDataAction,
+   ): SampleDataState {
+        return state;
+   }
+    `;
+
+  it('Should  preserve initial value of the state parameter', () => {
+    const result: String[] = merge(base, patch, false)
+      .split('\n')
+      .map((value) => value.trim())
+      .filter((value) => value != '');
+    expect(result.length).equal(4);
+    expect(result[0].indexOf('= initialState')).to.be.greaterThan(
+      -1,
+      'reducer should have parameter from base',
+    );
+  });
+  it('Initial parameter values should be overwritten when patchOverride is true.', () => {
+    const result: String[] = merge(base, patch, true)
+      .split('\n')
+      .map((value) => value.trim())
+      .filter((value) => value != '');
+    expect(result.length).equal(4);
+    let test = result[0].indexOf('= initialState');
+
+    expect(result[0].indexOf('= initialState')).to.be.equal(
+      -1,
+      'reducer should have parameter from patch ',
+    );
+  });
+});

--- a/test/parameter_initial_values_test.ts
+++ b/test/parameter_initial_values_test.ts
@@ -2,7 +2,7 @@ import merge from '../src/index';
 import { expect } from 'chai';
 import 'mocha';
 
-describe('should use the modifier from', () => {
+describe('Initial parameter values ', () => {
   const base = `
  export function reducer(
    state: SampleDataState = initialState,
@@ -20,7 +20,7 @@ describe('should use the modifier from', () => {
    }
     `;
 
-  it('Should  preserve initial value of the state parameter', () => {
+  it('should be preserved from the base', () => {
     const result: String[] = merge(base, patch, false)
       .split('\n')
       .map((value) => value.trim())
@@ -31,7 +31,7 @@ describe('should use the modifier from', () => {
       'reducer should have parameter from base',
     );
   });
-  it('Initial parameter values should be overwritten when patchOverride is true.', () => {
+  it('should be removed when patchOverride is true.', () => {
     const result: String[] = merge(base, patch, true)
       .split('\n')
       .map((value) => value.trim())


### PR DESCRIPTION
Solves #56 

Changes:
- Added support of PropertyAssignments that do not have keys.
- Added a test for properties without key.
- Added support for merging of array elements.

Related to vanishing parameter initial values:
- Added extraction, caching, and generation of Parameter initial values.
- Added a test for parameters with initial values.