### PR TITLE
#47 Numerical array elements get duplicated on successive mergers

### DIFF
--- a/test/arrays_test.ts
+++ b/test/arrays_test.ts
@@ -1,0 +1,33 @@
+import merge from "../src/index";
+import { expect } from "chai";
+import "mocha";
+
+describe("Declaring an object", () => {
+  describe("simple mergers", () => {
+    let  base = "let pageSizes: number[] = [8, 16, 24];",
+      patch = "";
+
+    it("should yield a valid object declaration.", () => {
+      let result: String = merge( base, patch, true).replace(/\n/g, "");
+     
+      expect(result).equal(
+        "let pageSizes: number[] = [8, 16, 24];"
+      );
+
+    });
+  });
+
+  describe("successive mergers", () => {
+    let  base = "let pageSizes: number[] = [8, 16, 24];",
+      patch = "";
+
+    it("should yield a valid object declaration.", () => {
+      let result: String = merge( merge(base, patch, true), patch, true).replace(/\n/g, "");
+     
+      expect(result).equal(
+        "let pageSizes: number[] = [8, 16, 24];"
+      );
+
+    });
+  });
+});


### PR DESCRIPTION
In the issue it was mentioned; that when successively merging an array with empty files, the result will be a duplicate array.

I wrote a test about it. but I always get the same array, just like it should be.

I don't know if I understood successive merge correctly

- "merge( merge(base, patch, true), patch, true)"

because the description doesn't say exactly what that means.