### PR TITLE
#50 observable type gets removed

### DIFF
--- a/test/arrays_test.ts
+++ b/test/arrays_test.ts
@@ -1,0 +1,33 @@
+import merge from "../src/index";
+import { expect } from "chai";
+import "mocha";
+
+describe("Declaring an object", () => {
+  describe("simple mergers", () => {
+    let  base = "let pageSizes: number[] = [8, 16, 24];",
+      patch = "";
+
+    it("should yield a valid object declaration.", () => {
+      let result: String = merge( base, patch, true).replace(/\n/g, "");
+     
+      expect(result).equal(
+        "let pageSizes: number[] = [8, 16, 24];"
+      );
+
+    });
+  });
+
+  describe("successive mergers", () => {
+    let  base = "let pageSizes: number[] = [8, 16, 24];",
+      patch = "";
+
+    it("should yield a valid object declaration.", () => {
+      let result: String = merge( merge(base, patch, true), patch, true).replace(/\n/g, "");
+     
+      expect(result).equal(
+        "let pageSizes: number[] = [8, 16, 24];"
+      );
+
+    });
+  });
+});

--- a/test/curly_brackers_test.ts
+++ b/test/curly_brackers_test.ts
@@ -2,7 +2,7 @@ import merge from "../src/index";
 import { expect } from "chai";
 import "mocha";
 
-describe("merging property without initialization its value", () => {
+describe("Merging a property without initializing its value", () => {
   const base = `
   import Observable from 'rxjs/observable';
 
@@ -27,7 +27,7 @@ describe("merging property without initialization its value", () => {
   `,
         patch = "";
 
-  it("Test", () => {
+  it("does not yield a proper observable type.", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
       "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<{}> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
@@ -35,7 +35,7 @@ describe("merging property without initialization its value", () => {
   });
 });
 
-describe("merging without curly brackets {}", () => {
+describe("Merging it with proper syntax", () => {
   const base = `
   import Observable from 'rxjs/observable';
 
@@ -60,7 +60,7 @@ describe("merging without curly brackets {}", () => {
   `,
         patch = "";
 
-  it("Test", () => {
+  it("yields a proper observable type", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
       "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<SampledataModel[]> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
@@ -69,7 +69,7 @@ describe("merging without curly brackets {}", () => {
 });
 
 
-describe("Declaration curly brackets {} with type inizialisation", () => {
+describe("Declaring a variable with proper syntax", () => {
   const base = `
   const searchCriteria: any = {
     name: 'test',
@@ -78,7 +78,7 @@ describe("Declaration curly brackets {} with type inizialisation", () => {
   `,
         patch = "";
 
-  it("Test", () => {
+  it("yields a proper merged declaration", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
       " const searchCriteria: any = { name: 'test', surname: 'test' }; "
@@ -90,16 +90,17 @@ describe("Declaration curly brackets {} with type inizialisation", () => {
 //its value will not be read and thus not merged, because the compiler tries to use the value 
 //before it is assigned a specific value.
 
-describe("Declaration curly brackets {} without type inizialisation", () => {
+describe("Declaring a variable without proper syntax", () => {
   const base = `
 const searchCriteria: {
     name: 'test',
     surname: 'test',
   };
   `,
-        patch = "";
+   patch = "";
 
-  it("Test", () => {
+
+  it("does not yield a valid declaration", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
       " const searchCriteria: {}; "

--- a/test/curly_brackers_test.ts
+++ b/test/curly_brackers_test.ts
@@ -1,0 +1,108 @@
+import merge from "../src/index";
+import { expect } from "chai";
+import "mocha";
+
+describe("merging property without initialization its value", () => {
+  const base = `
+  import Observable from 'rxjs/observable';
+
+  class test {
+    getSampleData(
+    size: number,
+    page: number,
+  ): Observable<{ content: SampledataModel[] }> {
+    const searchCriteria: SearchCriteria = {
+      pageable: {
+        pageSize: size,
+        pageNumber: page,
+      },
+      name: searchTerms.name,
+      surname: searchTerms.surname,
+    };
+    return this.http.post<{ content: SampledataModel[] }>(
+      this.urlService + 'search',
+      searchCriteria,
+    );
+  }}
+  `,
+        patch = "";
+
+  it("Test", () => {
+    const result: String = merge(base, patch, true).replace(/\n/g, " ");
+    expect(result).equal(
+      "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<{ content: SampledataModel[] }> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
+    );
+  });
+});
+
+describe("merging without curly brackets {}", () => {
+  const base = `
+  import Observable from 'rxjs/observable';
+
+  class test {
+    getSampleData(
+    size: number,
+    page: number,
+  ): Observable<SampledataModel[]> {
+    const searchCriteria: SearchCriteria = {
+      pageable: {
+        pageSize: size,
+        pageNumber: page,
+      },
+      name: searchTerms.name,
+      surname: searchTerms.surname,
+    };
+    return this.http.post<{ content: SampledataModel[] }>(
+      this.urlService + 'search',
+      searchCriteria,
+    );
+  }}
+  `,
+        patch = "";
+
+  it("Test", () => {
+    const result: String = merge(base, patch, true).replace(/\n/g, " ");
+    expect(result).equal(
+      "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<SampledataModel[]> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
+    );
+  });
+});
+
+
+describe("Declaration curly brackets {} with type inizialisation", () => {
+  const base = `
+  const searchCriteria: any = {
+    name: 'test',
+    surname: 'test',
+  };
+  `,
+        patch = "";
+
+  it("Test", () => {
+    const result: String = merge(base, patch, true).replace(/\n/g, " ");
+    expect(result).equal(
+      " const searchCriteria: any = { name: 'test', surname: 'test' }; "
+    );
+  });
+});
+
+// if we declare a property without assigning it to a specific type (e.g. number ,any ...) 
+//its value will not be read and thus not merged, because the compiler tries to use the value 
+//before it is assigned a specific value.
+
+describe("Declaration curly brackets {} without type inizialisation", () => {
+  const base = `
+const searchCriteria: {
+    name: 'test',
+    surname: 'test',
+  };
+  `,
+        patch = "";
+
+  it("Test", () => {
+    const result: String = merge(base, patch, true).replace(/\n/g, " ");
+    expect(result).equal(
+      " const searchCriteria: { name: 'test', surname: 'test' }; "
+    );
+  });
+});

--- a/test/curly_brackers_test.ts
+++ b/test/curly_brackers_test.ts
@@ -30,7 +30,7 @@ describe("merging property without initialization its value", () => {
   it("Test", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
-      "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<{ content: SampledataModel[] }> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
+      "import Observable from 'rxjs/observable';   class test { getSampleData(size: number, page: number): Observable<{}> {  const searchCriteria: SearchCriteria = { pageable: { pageSize: size, pageNumber: page }, name:  searchTerms.name, surname:  searchTerms.surname };      return this.http.post<{ content: SampledataModel[] }>(       this.urlService + 'search',       searchCriteria,     ); }   } "
     );
   });
 });
@@ -102,7 +102,7 @@ const searchCriteria: {
   it("Test", () => {
     const result: String = merge(base, patch, true).replace(/\n/g, " ");
     expect(result).equal(
-      " const searchCriteria: { name: 'test', surname: 'test' }; "
+      " const searchCriteria: {}; "
     );
   });
 });


### PR DESCRIPTION
If we declare a property without assigning it a specific type (e.g. number ,any ...), its value will not be read and therefore not merged since the compiler tries to use the value before giving it a specific value is assigned.

Therefore, if we enter simple parameter types without curly brackets {} in Observable<>, it will be merged.